### PR TITLE
兼容wokerman sendfile返回类型可能为null

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -262,9 +262,9 @@ class Response extends Message implements ResponseInterface
     /**
      * 发送文件
      * @param string $filename
-     * @return bool
+     * @return bool|null
      */
-    public function sendFile(string $filename): bool
+    public function sendFile(string $filename): ?bool
     {
         if ($this->isSwoole()) {
             return $this->swooleSendFile($filename);
@@ -404,9 +404,9 @@ class Response extends Message implements ResponseInterface
 
     /**
      * @param string $filename
-     * @return bool
+     * @return bool|null
      */
-    protected function workerManSendFile(string $filename): bool
+    protected function workerManSendFile(string $filename): ?bool
     {
         $headers = $this->getHeaders();
 


### PR DESCRIPTION
使用wokerman环境的时候，用`$vega->staticFile`方法会报`Return value of Mix\Http\Message\Response::sendFile() must be of the type bool, null returned`